### PR TITLE
Added one file processing from command line

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -4,7 +4,7 @@ num_layers : 2
 hidden_size : 300
 dropout : 0.7
 batch_size : 50
-train_frac : 0.7
+train_frac : 0.95
 learning_rate : 1e-5
 lr_decay_factor : 0.97
 grad_clip : 5
@@ -22,7 +22,7 @@ grad_clip : 5
 [general]
 # Whether to read config settings if pre-existing ones are found in checkpoint path
 use_config_file_if_checkpoint_exists : True
-steps_per_checkpoint : 50
+steps_per_checkpoint : 100
 checkpoint_dir : data/checkpoints/
 
 [training]

--- a/config.ini
+++ b/config.ini
@@ -19,11 +19,20 @@ learning_rate : 1e-5
 lr_decay_factor : 0.97
 grad_clip : 5
 
-#Whether to read config settings if pre-existing ones are found in checkpoint path
 [general]
+# Whether to read config settings if pre-existing ones are found in checkpoint path
 use_config_file_if_checkpoint_exists : True
 steps_per_checkpoint : 50
+checkpoint_dir : data/checkpoints/
 
-#these values were found experimentally
-max_input_seq_length : 3263
-max_target_seq_length : 517
+[training]
+training_dataset_dir : data/LibriSpeech/
+# max_input_seq_length is the maximum number of 0.025s chunks we allow in a single training (or test) example
+#   recommended : 800 (for 20 seconds)
+# max_target_seq_length is the maximum number of letters we allow in a single training (or test) example output
+#   recommended : 400 characters (for 20 seconds seems reasonnable) - padding will occurs on the beginning if needed
+# Warnings :
+#  - Those two values need to be consistent one with the other
+#  - These values depends on your dataset used for training
+max_input_seq_length : 800
+max_target_seq_length : 400

--- a/models/AcousticModel.py
+++ b/models/AcousticModel.py
@@ -72,7 +72,8 @@ class AcousticModel(object):
         b_i = tf.get_variable("input_b", [hidden_size])
 
         # make rnn inputs
-        inputs = [tf.matmul(tf.squeeze(i), w_i) + b_i for i in tf.split(0, self.max_input_seq_length, self.inputs)]
+        inputs = [tf.matmul(tf.squeeze(i, squeeze_dims=[0]), w_i) + b_i
+                  for i in tf.split(0, self.max_input_seq_length, self.inputs)]
 
         # set rnn init state to 0s
         initial_state = cell.zero_state(self.batch_size, tf.float32)
@@ -88,7 +89,8 @@ class AcousticModel(object):
         b_o = tf.get_variable("output_b", [num_labels])
 
         # compute logits
-        self.logits = [tf.matmul(tf.squeeze(i), w_o) + b_o for i in tf.split(0, self.max_input_seq_length, rnn_output)]
+        self.logits = [tf.matmul(tf.squeeze(i, squeeze_dims=[0]), w_o) + b_o
+                       for i in tf.split(0, self.max_input_seq_length, rnn_output)]
 
         if forward_only:
             self.logits = tf.pack(self.logits)

--- a/models/AcousticModel.py
+++ b/models/AcousticModel.py
@@ -31,8 +31,10 @@ class AcousticModel(object):
         dropout - probability of dropping hidden weights
         batch_size - number of training examples fed at once
         learning_rate - learning rate parameter fed to optimizer
+        lr_decay_factor - decay factor of the learning rate
         grad_clip - max gradient size (prevent exploding gradients)
-        max_seq_length - maximum length of input vector sequence
+        max_input_seq_length - maximum length of input vector sequence
+        max_target_seq_length - maximum length of ouput vector sequence
         input_dim - dimension of input vector
         forward_only - whether to build back prop nodes or not
         '''
@@ -119,9 +121,11 @@ class AcousticModel(object):
     def getBatch(self, dataset, batch_pointer, is_train):
         '''
         Inputs:
-        dataset - tuples of (numpy file, transcribed_text)
+          dataset - tuples of (wav file, transcribed_text)
+          batch_pointer - start point in dataset from where to take the batch
+          is_train - training mode (to choose which pipe to use)
         Returns:
-        input_feat_vecs, input_feat_vec_lengths, target_lengths,
+          input_feat_vecs, input_feat_vec_lengths, target_lengths,
             target_labels, target_indices
         '''
         already_processed = self.batch_size * batch_pointer

--- a/stt.py
+++ b/stt.py
@@ -1,0 +1,154 @@
+'''
+Main program to use the speech recognizer.
+'''
+
+from tensorflow.python.platform import gfile
+from models.AcousticModel import AcousticModel
+import tensorflow as tf
+import os
+import time
+import util.hyperparams as hyperparams
+import util.audioprocessor as audioprocessor
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
+import argparse
+
+
+flags = tf.app.flags
+FLAGS = flags.FLAGS
+flags.DEFINE_string("config_file", "config.ini", "Path to configuration file with hyper-parameters.")
+
+
+def main():
+    hyper_params = checkGetHyperParamDic()
+    max_input_seq_length = hyper_params["max_input_seq_length"]
+    audio_processor = audioprocessor.AudioProcessor(max_input_seq_length)
+    prog_params = parse_args()
+
+    feat_vec, original_feat_vec_length = audio_processor.processFLACAudio(prog_params['file'])
+    if original_feat_vec_length > max_input_seq_length:
+        print("File too long")
+        return
+
+    print("Using checkpoint {0}".format(hyper_params["checkpoint_dir"]))
+    print("Using hyper params: {0}".format(hyper_params))
+
+    with tf.Session() as sess:
+        # create model
+        print("Building model... (this takes a while)")
+        model = createAcousticModel(sess, hyper_params)
+
+        (a, b) = feat_vec.shape
+        feat_vec = feat_vec.reshape((a, 1, b))
+        logit = model.process_input(sess, feat_vec, [original_feat_vec_length])
+        logit = logit.squeeze()
+        char_values = logit.argmax(axis=1)
+        transcribed_text = ""
+        previous_char = ""
+        for i in char_values:
+            char = "abcdefghijklmnopqrstuvwxyz .'_-"[i]
+            if char != previous_char:
+                transcribed_text += char
+            previous_char = char
+
+        print(transcribed_text)
+
+
+def createAcousticModel(session, hyper_params):
+    num_labels = 31
+    input_dim = 123
+    model = AcousticModel(num_labels, hyper_params["num_layers"],
+                          hyper_params["hidden_size"], hyper_params["dropout"],
+                          1, hyper_params["learning_rate"],
+                          hyper_params["lr_decay_factor"], hyper_params["grad_clip"],
+                          hyper_params["max_input_seq_length"],
+                          hyper_params["max_target_seq_length"],
+                          input_dim,
+                          forward_only=True)
+    ckpt = tf.train.get_checkpoint_state(hyper_params["checkpoint_dir"])
+    if ckpt and gfile.Exists(ckpt.model_checkpoint_path):
+        print("Reading model parameters from {0}".format(ckpt.model_checkpoint_path))
+        model.saver.restore(session, ckpt.model_checkpoint_path)
+    else:
+        print("Created model with fresh parameters.")
+        session.run(tf.initialize_all_variables())
+    return model
+
+
+def checkGetHyperParamDic():
+    '''
+    Retrieves hyper parameter information from either config file or checkpoint
+    '''
+    hyper_params = readConfigFile()
+    if not os.path.exists(hyper_params["checkpoint_dir"]):
+        os.makedirs(hyper_params["checkpoint_dir"])
+    serializer = hyperparams.HyperParameterHandler(hyper_params["checkpoint_dir"])
+    if serializer.checkExists():
+        if serializer.checkChanged(hyper_params):
+            if not hyper_params["use_config_file_if_checkpoint_exists"]:
+                hyper_params = serializer.getParams()
+                print("Restoring hyper params from previous checkpoint...")
+            else:
+                new_checkpoint_dir = "{0}_hidden_size_{1}_numlayers_{2}_dropout_{3}".format(
+                    int(time.time()),
+                    hyper_params["hidden_size"],
+                    hyper_params["num_layers"],
+                    hyper_params["dropout"])
+                new_checkpoint_dir = os.path.join(hyper_params["checkpoint_dir"],
+                                                  new_checkpoint_dir)
+                os.makedirs(new_checkpoint_dir)
+                hyper_params["checkpoint_dir"] = new_checkpoint_dir
+                serializer = hyperparams.HyperParameterHandler(hyper_params["checkpoint_dir"])
+                serializer.saveParams(hyper_params)
+        else:
+            print("No hyper parameter changed detected, using old checkpoint...")
+    else:
+        serializer.saveParams(hyper_params)
+        print("No hyper params detected at checkpoint... reading config file")
+    return hyper_params
+
+
+def readConfigFile():
+    '''
+    Reads in config file, returns dictionary of network params
+    '''
+    config = configparser.ConfigParser()
+    config.read(FLAGS.config_file)
+    dic = {}
+    acoustic_section = "acoustic_network_params"
+    general_section = "general"
+    training_section = "training"
+    dic["num_layers"] = config.getint(acoustic_section, "num_layers")
+    dic["hidden_size"] = config.getint(acoustic_section, "hidden_size")
+    dic["dropout"] = config.getfloat(acoustic_section, "dropout")
+    dic["batch_size"] = config.getint(acoustic_section, "batch_size")
+    dic["train_frac"] = config.getfloat(acoustic_section, "train_frac")
+    dic["learning_rate"] = config.getfloat(acoustic_section, "learning_rate")
+    dic["lr_decay_factor"] = config.getfloat(acoustic_section, "lr_decay_factor")
+    dic["grad_clip"] = config.getint(acoustic_section, "grad_clip")
+    dic["use_config_file_if_checkpoint_exists"] = config.getboolean(general_section,
+                                                                    "use_config_file_if_checkpoint_exists")
+    dic["steps_per_checkpoint"] = config.getint(general_section, "steps_per_checkpoint")
+    dic["checkpoint_dir"] = config.get(general_section, "checkpoint_dir")
+    dic["training_dataset_dir"] = config.get(training_section, "training_dataset_dir")
+    dic["max_input_seq_length"] = config.getint(training_section, "max_input_seq_length")
+    dic["max_target_seq_length"] = config.getint(training_section, "max_target_seq_length")
+    return dic
+
+
+def parse_args():
+    """
+    Parses the command line input.
+
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('file', type=str, help='wav file to process')
+    args = parser.parse_args()
+    prog_params = {'file': args.file}
+    return prog_params
+
+
+if __name__ == "__main__":
+    main()

--- a/util/dataprocessor.py
+++ b/util/dataprocessor.py
@@ -12,23 +12,12 @@ import util.audioprocessor as audioprocessor
 
 
 class DataProcessor(object):
-    def __init__(self, data_path, raw_data_path, config_dic):
-        self.data_path = data_path
+    def __init__(self, raw_data_path):
         self.raw_data_path = raw_data_path
-        self.config_dic = config_dic
+        self.data_dirs = self.checkWhichDataFoldersArePresent()
 
     def run(self):
-        # First make output directories
-        self.setupProcessedDataDirs()
-
-        # Check if processor needs to be run
-        if os.path.exists(os.path.join(self.train_dir, "master_text_file.txt"))\
-            and os.path.exists(os.path.join(self.test_dir, "master_text_file.txt")):
-            print("No need to run data processor...")
-            return
-
-        # Next check which data folders are present
-        self.data_dirs = self.checkWhichDataFoldersArePresent()
+        # Check which data folders are present
         if len(self.data_dirs) == 0:
             print("Something went wrong, no data detected, check data directory..")
             return
@@ -46,23 +35,14 @@ class DataProcessor(object):
             for audio_file_name in audio_file_text_pairs:
                 if audio_file_name[0].endswith(".flac"):
                     audio_processor.convertAndDeleteFLAC(audio_file_name[0])
-                    audio_file_text_pairs_final.append((audio_file_name[0].replace(".flac", ".wav"), audio_file_name[1]))
+                    audio_file_text_pairs_final.append((audio_file_name[0].replace(".flac", ".wav"),
+                                                        audio_file_name[1]))
                 else:
                     audio_file_text_pairs_final.append((audio_file_name[0], audio_file_name[1]))
         else:
             audio_file_text_pairs_final = audio_file_text_pairs
 
         return audio_file_text_pairs_final
-
-    def readInMetaInformation(self):
-        file_info = []
-        with open(os.path.join(self.raw_data_path,
-            "CHAPTERS.txt")) as data_file:
-            for line in data_file:
-                info = line.split("|")
-                if info[3].replace(" ", "") in self.data_dirs:
-                    file_info.append(info)
-        return file_info
 
     def getFileNameTextPairs(self):
         '''
@@ -76,10 +56,12 @@ class DataProcessor(object):
         for d in self.data_dirs:
             root_search_path = os.path.join(self.raw_data_path, d)
             for root, subdirs, files in os.walk(root_search_path):
-                flac_audio_files = [os.path.join(root, audio_file) for audio_file in files if audio_file.endswith(".flac")]
-                wav_audio_files = [os.path.join(root, audio_file) for audio_file in files if audio_file.endswith(".wav")]
+                flac_audio_files = [os.path.join(root, audio_file)
+                                    for audio_file in files if audio_file.endswith(".flac")]
+                wav_audio_files = [os.path.join(root, audio_file)
+                                   for audio_file in files if audio_file.endswith(".wav")]
                 text_files = [os.path.join(root, text_file) for
-                    text_file in files if text_file.endswith(".txt")]
+                              text_file in files if text_file.endswith(".txt")]
                 if len(flac_audio_files) > 0:
                     # We have at least one file to convert
                     will_convert = True
@@ -99,18 +81,10 @@ class DataProcessor(object):
                                     break
         return audio_file_text_pairs, will_convert
 
-    def setupProcessedDataDirs(self):
-        self.train_dir = os.path.join(self.data_path, "train/")
-        self.test_dir = os.path.join(self.data_path, "test/")
-        if not os.path.exists(self.train_dir):
-            os.makedirs(self.train_dir)
-        if not os.path.exists(self.test_dir):
-            os.makedirs(self.test_dir)
-
     def checkWhichDataFoldersArePresent(self):
         dirs_to_check = ["dev-clean", "train-other-500", "train-other-100",
-        "train-clean-100", "train-clean-360", "test-clean",
-        "test-other", "dev-other"]
+                         "train-clean-100", "train-clean-360", "test-clean",
+                         "test-other", "dev-other"]
         dirs_available = [name for name in os.listdir(self.raw_data_path)]
         dirs_allowed = []
         for d in dirs_available:


### PR DESCRIPTION
Hi,
This is the last part and we will be up to date.
I've exported checkpoint_dir and training_dataset_dir in the config file, make a new launcher to process one file from command line (TODO : quite some duplicate code with train.py which I should fix, documentation should also explain how to use).
There's also added information in the config file about max_input_seq_length and max_target_seq_length.
And finally I removed unused code.

Not related to this pull request but I think your initial idea of saving the vector file for each wav file was good. On my computer it take 8 to 10 seconds waiting for the process to feed input data, at each step !
I will probably have a look into this.