### PR TITLE
Refactor

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -4,7 +4,7 @@ num_layers : 2
 hidden_size : 300
 dropout : 0.7
 batch_size : 50
-train_frac : 0.95
+train_frac : 0.98
 learning_rate : 1e-5
 lr_decay_factor : 0.97
 grad_clip : 5
@@ -27,12 +27,18 @@ checkpoint_dir : data/checkpoints/
 
 [training]
 training_dataset_dir : data/LibriSpeech/
-# max_input_seq_length is the maximum number of 0.025s chunks we allow in a single training (or test) example
-#   recommended : 800 (for 20 seconds)
+# max_input_seq_length is the maximum number of 0.01s chunks we allow in a single training (or test) example
+#   Recommended : 2000 chuncks (for 20 seconds) but it require more than 8 Gb of memory
 # max_target_seq_length is the maximum number of letters we allow in a single training (or test) example output
-#   recommended : 400 characters (for 20 seconds seems reasonnable) - padding will occurs on the beginning if needed
+#   Must be less than 65535 (int16 for reduced memory consumption)
+#   Recommended : 400 characters (for 20 seconds seems reasonnable in most languages)
 # Warnings :
 #  - Those two values need to be consistent one with the other
 #  - These values depends on your dataset used for training
+# Small config (8 Gb memory) :
+#  - use 800 / 250 respectively
+#  - remove wav files over this limit from the dataset
+#     (CAREFULL recursive delete : find -name *.wav -size +250k -exec rm {} \;)
 max_input_seq_length : 800
-max_target_seq_length : 400
+max_target_seq_length : 250
+

--- a/stt.py
+++ b/stt.py
@@ -27,9 +27,6 @@ def main():
         print("File too long")
         return
 
-    print("Using checkpoint {0}".format(hyper_params["checkpoint_dir"]))
-    print("Using hyper params: {0}".format(hyper_params))
-
     with tf.Session() as sess:
         # create model
         print("Building model... (this takes a while)")

--- a/stt.py
+++ b/stt.py
@@ -5,14 +5,8 @@ Main program to use the speech recognizer.
 from tensorflow.python.platform import gfile
 from models.AcousticModel import AcousticModel
 import tensorflow as tf
-import os
-import time
 import util.hyperparams as hyperparams
 import util.audioprocessor as audioprocessor
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
 import argparse
 
 
@@ -22,7 +16,8 @@ flags.DEFINE_string("config_file", "config.ini", "Path to configuration file wit
 
 
 def main():
-    hyper_params = checkGetHyperParamDic()
+    serializer = hyperparams.HyperParameterHandler(FLAGS.config_file)
+    hyper_params = serializer.getHyperParams()
     max_input_seq_length = hyper_params["max_input_seq_length"]
     audio_processor = audioprocessor.AudioProcessor(max_input_seq_length)
     prog_params = parse_args()
@@ -75,67 +70,6 @@ def createAcousticModel(session, hyper_params):
         print("Created model with fresh parameters.")
         session.run(tf.initialize_all_variables())
     return model
-
-
-def checkGetHyperParamDic():
-    '''
-    Retrieves hyper parameter information from either config file or checkpoint
-    '''
-    hyper_params = readConfigFile()
-    if not os.path.exists(hyper_params["checkpoint_dir"]):
-        os.makedirs(hyper_params["checkpoint_dir"])
-    serializer = hyperparams.HyperParameterHandler(hyper_params["checkpoint_dir"])
-    if serializer.checkExists():
-        if serializer.checkChanged(hyper_params):
-            if not hyper_params["use_config_file_if_checkpoint_exists"]:
-                hyper_params = serializer.getParams()
-                print("Restoring hyper params from previous checkpoint...")
-            else:
-                new_checkpoint_dir = "{0}_hidden_size_{1}_numlayers_{2}_dropout_{3}".format(
-                    int(time.time()),
-                    hyper_params["hidden_size"],
-                    hyper_params["num_layers"],
-                    hyper_params["dropout"])
-                new_checkpoint_dir = os.path.join(hyper_params["checkpoint_dir"],
-                                                  new_checkpoint_dir)
-                os.makedirs(new_checkpoint_dir)
-                hyper_params["checkpoint_dir"] = new_checkpoint_dir
-                serializer = hyperparams.HyperParameterHandler(hyper_params["checkpoint_dir"])
-                serializer.saveParams(hyper_params)
-        else:
-            print("No hyper parameter changed detected, using old checkpoint...")
-    else:
-        serializer.saveParams(hyper_params)
-        print("No hyper params detected at checkpoint... reading config file")
-    return hyper_params
-
-
-def readConfigFile():
-    '''
-    Reads in config file, returns dictionary of network params
-    '''
-    config = configparser.ConfigParser()
-    config.read(FLAGS.config_file)
-    dic = {}
-    acoustic_section = "acoustic_network_params"
-    general_section = "general"
-    training_section = "training"
-    dic["num_layers"] = config.getint(acoustic_section, "num_layers")
-    dic["hidden_size"] = config.getint(acoustic_section, "hidden_size")
-    dic["dropout"] = config.getfloat(acoustic_section, "dropout")
-    dic["batch_size"] = config.getint(acoustic_section, "batch_size")
-    dic["train_frac"] = config.getfloat(acoustic_section, "train_frac")
-    dic["learning_rate"] = config.getfloat(acoustic_section, "learning_rate")
-    dic["lr_decay_factor"] = config.getfloat(acoustic_section, "lr_decay_factor")
-    dic["grad_clip"] = config.getint(acoustic_section, "grad_clip")
-    dic["use_config_file_if_checkpoint_exists"] = config.getboolean(general_section,
-                                                                    "use_config_file_if_checkpoint_exists")
-    dic["steps_per_checkpoint"] = config.getint(general_section, "steps_per_checkpoint")
-    dic["checkpoint_dir"] = config.get(general_section, "checkpoint_dir")
-    dic["training_dataset_dir"] = config.get(training_section, "training_dataset_dir")
-    dic["max_input_seq_length"] = config.getint(training_section, "max_input_seq_length")
-    dic["max_target_seq_length"] = config.getint(training_section, "max_target_seq_length")
-    return dic
 
 
 def parse_args():

--- a/train.py
+++ b/train.py
@@ -8,16 +8,12 @@ http://arxiv.org/pdf/1601.06581v2.pdf
 from tensorflow.python.platform import gfile
 from models.AcousticModel import AcousticModel
 import tensorflow as tf
-import sys
-import os
-import time
 import util.dataprocessor as dataprocessor
 import util.hyperparams as hyperparams
 try:
     import ConfigParser as configparser
 except ImportError:
     import configparser
-from multiprocessing import Process, Pipe
 from math import floor
 
 flags = tf.app.flags
@@ -35,10 +31,6 @@ def main():
     train_set = text_audio_pairs[:num_train]
     test_set = text_audio_pairs[num_train:]
     print("Using {0} size of test set".format(len(test_set)))
-    # setting up piplines to be able to load data async (one for test set, one for train)
-    # TODO tensorflow probably has something built in for this, look into it
-    parent_train_conn, child_train_conn = Pipe()
-    parent_test_conn, child_test_conn = Pipe()
 
     with tf.Session() as sess:
         # create model
@@ -46,81 +38,8 @@ def main():
         model = createAcousticModel(sess, hyper_params)
         print("Setting up audio processor...")
         model.initializeAudioProcessor(hyper_params["max_input_seq_length"])
-        print("Setting up piplines to test and train data...")
-        model.setConnections(child_test_conn, child_train_conn)
-
-        num_test_batches = model.getNumBatches(test_set)
-        num_train_batches = model.getNumBatches(train_set)
-
-        train_batch_pointer = 0
-        test_batch_pointer = 0
-
-        async_train_loader = Process(
-            target=model.getBatch,
-            args=(train_set, train_batch_pointer, True))
-        async_train_loader.start()
-
-        step_time, loss = 0.0, 0.0
-        current_step = 0
-        previous_losses = []
-        while True:
-            # begin timer
-            start_time = time.time()
-            # receive batch from pipe
-            step_batch_inputs = parent_train_conn.recv()
-            # async_train_loader.join()
-
-            train_batch_pointer = step_batch_inputs[5] % num_train_batches
-
-            # begin fetching other batch while graph processes previous one
-            async_train_loader = Process(
-                target=model.getBatch,
-                args=(train_set, train_batch_pointer, True))
-            async_train_loader.start()
-            # print step_batch_inputs[0]
-            _, step_loss = model.step(sess, step_batch_inputs[0], step_batch_inputs[1],
-                                      step_batch_inputs[2], step_batch_inputs[3],
-                                      step_batch_inputs[4], forward_only=False)
-            # print _
-            print("Step {0} with loss {1}".format(current_step, step_loss))
-            step_time += (time.time() - start_time) / hyper_params["steps_per_checkpoint"]
-            loss += step_loss / hyper_params["steps_per_checkpoint"]
-            current_step += 1
-            if current_step % hyper_params["steps_per_checkpoint"] == 0:
-                print("global step %d learning rate %.4f step-time %.2f loss %.2f" %
-                      (model.global_step.eval(), model.learning_rate.eval(), step_time, loss))
-                # Decrease learning rate if no improvement was seen over last 3 times.
-                if len(previous_losses) > 2 and loss > max(previous_losses[-3:]):
-                    sess.run(model.learning_rate_decay_op)
-                previous_losses.append(loss)
-
-                checkpoint_path = os.path.join(hyper_params["checkpoint_dir"], "acousticmodel.ckpt")
-                model.saver.save(sess, checkpoint_path, global_step=model.global_step)
-                step_time, loss = 0.0, 0.0
-                # begin loading test data async
-                # (uses different pipline than train data)
-                async_test_loader = Process(
-                    target=model.getBatch,
-                    args=(test_set, test_batch_pointer, False))
-                async_test_loader.start()
-                print(num_test_batches)
-                for i in range(num_test_batches):
-                    print("On {0}th training iteration".format(i))
-                    eval_inputs = parent_test_conn.recv()
-                    # async_test_loader.join()
-                    test_batch_pointer = eval_inputs[5] % num_test_batches
-                    # tell audio processor to go get another batch ready
-                    # while we run last one through the graph
-                    if i != num_test_batches - 1:
-                        async_test_loader = Process(
-                            target=model.getBatch,
-                            args=(test_set, test_batch_pointer, False))
-                        async_test_loader.start()
-                    _, loss = model.step(sess, eval_inputs[0], eval_inputs[1],
-                                         eval_inputs[2], eval_inputs[3],
-                                         eval_inputs[4], forward_only=True)
-                print("\tTest: loss %.2f" % loss)
-                sys.stdout.flush()
+        print("Start training...")
+        model.train(sess, test_set, train_set, hyper_params["steps_per_checkpoint"], hyper_params["checkpoint_dir"])
 
 
 def createAcousticModel(session, hyper_params):

--- a/util/hyperparams.py
+++ b/util/hyperparams.py
@@ -104,5 +104,4 @@ class HyperParameterHandler(object):
         dic["training_dataset_dir"] = config.get(training_section, "training_dataset_dir")
         dic["max_input_seq_length"] = config.getint(training_section, "max_input_seq_length")
         dic["max_target_seq_length"] = config.getint(training_section, "max_target_seq_length")
-        dic["save_input_vec"] = config.getboolean(training_section, "save_input_vec")
         return dic

--- a/util/hyperparams.py
+++ b/util/hyperparams.py
@@ -4,11 +4,54 @@ of hyperparameters (for use in checkpoint restoration and sampling)
 '''
 import os
 import pickle
+import time
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
 
 
 class HyperParameterHandler(object):
-    def __init__(self, path):
-        self.file_path = os.path.join(path, "hyperparams.p")
+    def __init__(self, config_file):
+        '''
+        Retrieves hyper parameter information from either config file or checkpoint
+        '''
+        self.hyper_params = self.readConfigFile(config_file)
+
+        print("Using checkpoint {0}".format(self.hyper_params["checkpoint_dir"]))
+        print("Using hyper params: {0}".format(self.hyper_params))
+
+        # Create checkpoint dir if needed
+        if not os.path.exists(self.hyper_params["checkpoint_dir"]):
+            os.makedirs(self.hyper_params["checkpoint_dir"])
+
+        self.file_path = os.path.join(self.hyper_params["checkpoint_dir"], "hyperparams.p")
+        if self.checkExists():
+            if self.checkChanged(self.hyper_params):
+                if not self.hyper_params["use_config_file_if_checkpoint_exists"]:
+                    self.hyper_params = self.getParams()
+                    print("Restoring hyper params from previous checkpoint...")
+                else:
+                    new_checkpoint_dir = "{0}_hidden_size_{1}_numlayers_{2}_dropout_{3}".format(
+                        int(time.time()),
+                        self.hyper_params["hidden_size"],
+                        self.hyper_params["num_layers"],
+                        self.hyper_params["dropout"])
+                    new_checkpoint_dir = os.path.join(self.hyper_params["checkpoint_dir"],
+                                                      new_checkpoint_dir)
+                    os.makedirs(new_checkpoint_dir)
+                    self.hyper_params["checkpoint_dir"] = new_checkpoint_dir
+                    self.file_path = os.path.join(self.hyper_params["checkpoint_dir"], "hyperparams.p")
+                    self.saveParams(self.hyper_params)
+            else:
+                print("No hyper parameter changed detected, using old checkpoint...")
+        else:
+            self.saveParams(self.hyper_params)
+            print("No hyper params detected at checkpoint... reading config file")
+        return
+
+    def getHyperParams(self):
+        return self.hyper_params
 
     def saveParams(self, dic):
         with open(self.file_path, 'wb') as handle:
@@ -35,3 +78,31 @@ class HyperParameterHandler(object):
                 old_params["batch_size"] != new_params["batch_size"]
         else:
             return False
+
+    def readConfigFile(self, config_file):
+        '''
+        Reads in config file, returns dictionary of network params
+        '''
+        config = configparser.ConfigParser()
+        config.read(config_file)
+        dic = {}
+        acoustic_section = "acoustic_network_params"
+        general_section = "general"
+        training_section = "training"
+        dic["num_layers"] = config.getint(acoustic_section, "num_layers")
+        dic["hidden_size"] = config.getint(acoustic_section, "hidden_size")
+        dic["dropout"] = config.getfloat(acoustic_section, "dropout")
+        dic["batch_size"] = config.getint(acoustic_section, "batch_size")
+        dic["train_frac"] = config.getfloat(acoustic_section, "train_frac")
+        dic["learning_rate"] = config.getfloat(acoustic_section, "learning_rate")
+        dic["lr_decay_factor"] = config.getfloat(acoustic_section, "lr_decay_factor")
+        dic["grad_clip"] = config.getint(acoustic_section, "grad_clip")
+        dic["use_config_file_if_checkpoint_exists"] = config.getboolean(general_section,
+                                                                        "use_config_file_if_checkpoint_exists")
+        dic["steps_per_checkpoint"] = config.getint(general_section, "steps_per_checkpoint")
+        dic["checkpoint_dir"] = config.get(general_section, "checkpoint_dir")
+        dic["training_dataset_dir"] = config.get(training_section, "training_dataset_dir")
+        dic["max_input_seq_length"] = config.getint(training_section, "max_input_seq_length")
+        dic["max_target_seq_length"] = config.getint(training_section, "max_target_seq_length")
+        dic["save_input_vec"] = config.getboolean(training_section, "save_input_vec")
+        return dic


### PR DESCRIPTION
Hi,

Here is a bit of re-factorization : 
- config file management sent into hyperparameters.py
- training sent into the model

I have also worked on the file size problem (cutting) and optimization for small configs. I came up with two parameters set : one is recommended because it can use most of the dataset, one is a optimal config for using 8 Gb of memory without swapping.

Now train.py and stt.py could be merged into one file, the resulting file could manage training with a '--train' parameter.
I was thinking to rename stt.py to "rnn-speech" (project name) or keep stt.py (meaning "speech to text", shorter in everyday use :-) ). Do you have any preference ? Do you prefer to keep two separate launchers ?

Antoine.