### PR TITLE
Simpler management of starting point and global_step

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -50,7 +50,9 @@ grad_clip : 5
 [general]
 # Whether to read config settings if pre-existing ones are found in checkpoint path
 use_config_file_if_checkpoint_exists : True
+# Frequency at which to save the model
 steps_per_checkpoint : 100
+# Frequency at which to evaluate on the test set. This must be a multiple of steps_per_checkpoint
 steps_per_evaluation : 1000
 checkpoint_dir : data/checkpoints/
 

--- a/stt.py
+++ b/stt.py
@@ -25,7 +25,8 @@ def main():
     hyper_params["input_dim"] = audio_processor.feature_size
 
     if prog_params['train'] is True:
-        train_rnn(audio_processor, hyper_params, prog_params, size_ordering=hyper_params["dataset_size_ordering"])
+        train_set, test_set = load_training_dataset(audio_processor, hyper_params)
+        train_rnn(train_set, test_set, hyper_params, prog_params)
     elif prog_params['file'] is not None:
         process_file(audio_processor, hyper_params, prog_params['file'])
     elif prog_params['record'] is True:
@@ -52,11 +53,11 @@ def build_training_rnn(sess, hyper_params, prog_params, overriden_max_input_seq_
     return model
 
 
-def train_rnn(audio_processor, hyper_params, prog_params, size_ordering='False'):
+def load_training_dataset(audio_processor, hyper_params):
     # Load the train set data
     data_processor = dataprocessor.DataProcessor(hyper_params["training_dataset_dirs"], audio_processor,
                                                  file_cache=hyper_params["training_filelist_cache"],
-                                                 size_ordering=size_ordering)
+                                                 size_ordering=hyper_params["dataset_size_ordering"])
     train_set = data_processor.run()
     if hyper_params["test_dataset_dirs"] is not None:
         # Load the test set data
@@ -73,7 +74,11 @@ def train_rnn(audio_processor, hyper_params, prog_params, size_ordering='False')
 
     logging.info("Using %d files in train set", len(train_set))
     logging.info("Using %d size of test set", len(test_set))
+    return train_set, test_set
 
+
+def train_rnn(train_set, test_set, hyper_params, prog_params):
+    # Configure tensorflow's session
     config = tf.ConfigProto()
     jit_level = 0
     if prog_params["XLA"]:
@@ -88,37 +93,30 @@ def train_rnn(audio_processor, hyper_params, prog_params, size_ordering='False')
     else:
         run_options = None
 
-    # Retrieve the step counter if there is a checkpoint to load
-    # TODO: find a way to retrieve the step_num without requiring to build the model
-    if tf.train.get_checkpoint_state(hyper_params["checkpoint_dir"]):
-        with tf.Session(config=config) as sess:
-            model = build_training_rnn(sess, hyper_params, prog_params, overriden_max_input_seq_length=1)
-            step_num = model.global_step.eval()
-        tf.reset_default_graph()
-    else:
-        step_num = 1
-
     full_run_size = hyper_params["batch_size"] * hyper_params["mini_batch_size"]
-
+    end_pos = None
     previous_mean_error_rate = None
-    previous_epoch = None
+    step_num = 0
+    epoch = 1
     while True:
-        # Evaluate the epoch number
-        epoch = ((step_num - 1) * full_run_size) // len(train_set)
-        if previous_epoch is not None and epoch != previous_epoch:
-            if size_ordering == 'False' or size_ordering == 'First_run_only':
-                logging.info("New epoch {0}: shuffling training dataset".format(epoch))
-                shuffle(train_set)
-        previous_epoch = epoch
-
         # Select training data
-        start_pos = ((step_num - 1) * full_run_size) % len(train_set)
+        if end_pos is None:
+            start_pos = prog_params["start_from"]
+            if start_pos > len(train_set):
+                raise ValueError("Invalid program parameter 'start_from' : higher than training dataset size")
+        else:
+            start_pos = end_pos
         end_pos = (start_pos + (full_run_size * hyper_params["steps_per_checkpoint"])) % len(train_set)
+        # Check if end of training set is reached
         if end_pos > start_pos:
             session_set = train_set[start_pos:end_pos]
         else:
             session_set = train_set[start_pos:]
             session_set += train_set[:end_pos]
+            epoch += 1
+            if hyper_params["dataset_size_ordering"] in ['False', 'First_run_only']:
+                logging.info("New epoch {0}: shuffling training dataset for next time".format(epoch))
+                shuffle(train_set)
 
         # Find max_input_seq_length for this training data
         local_input_seq_length = max(session_set, key=lambda x: x[2])[2] + 10
@@ -135,21 +133,32 @@ def train_rnn(audio_processor, hyper_params, prog_params, size_ordering='False')
             local_audio_processor = audioprocessor.AudioProcessor(local_input_seq_length,
                                                                   hyper_params["signal_processing"])
             # Run training
-            step_num, _ = model.fit(sess, local_audio_processor, session_set, hyper_params["mini_batch_size"],
-                                    rnn_state_reset_ratio=hyper_params["rnn_state_reset_ratio"],
-                                    run_options=run_options, run_metadata=run_metadata)
+            _, _ = model.fit(sess, local_audio_processor, session_set, hyper_params["mini_batch_size"],
+                             rnn_state_reset_ratio=hyper_params["rnn_state_reset_ratio"],
+                             run_options=run_options, run_metadata=run_metadata)
             model.save(sess, hyper_params["checkpoint_dir"])
+            step_num += hyper_params["steps_per_checkpoint"]
 
         tf.reset_default_graph()
 
         # Run an evaluation session
         if step_num % hyper_params["steps_per_evaluation"] == 0:
             with tf.Session(config=config) as sess:
+                # Find max_input_seq_length for this evaluation data
+                local_input_seq_length = max(test_set, key=lambda x: x[2])[2] + 10
+                local_input_seq_length = min(local_input_seq_length, hyper_params["max_input_seq_length"])
+                logging.info("Start a session with local_input_seq_length = %d", local_input_seq_length)
+
                 # create model
-                model = build_training_rnn(sess, hyper_params, prog_params)
+                model = build_training_rnn(sess, hyper_params, prog_params,
+                                           overriden_max_input_seq_length=local_input_seq_length)
+
+                # Create a local audio_processor set for the local max_input_seq_length
+                local_audio_processor = audioprocessor.AudioProcessor(local_input_seq_length,
+                                                                      hyper_params["signal_processing"])
 
                 # Evaluate
-                mean_loss, mean_error_rate, _ = model.evaluate_basic(sess, test_set, audio_processor,
+                mean_loss, mean_error_rate, _ = model.evaluate_basic(sess, test_set, local_audio_processor,
                                                                      run_options=run_options, run_metadata=run_metadata)
 
                 # Decay the learning rate if the model is not improving
@@ -166,7 +175,7 @@ def train_rnn(audio_processor, hyper_params, prog_params, size_ordering='False')
 
             tf.reset_default_graph()
 
-        if (prog_params["max_epoch"] is not None) and (step_num >= prog_params["max_epoch"]):
+        if (prog_params["max_epoch"] is not None) and (epoch > prog_params["max_epoch"]):
             break
 
 
@@ -267,6 +276,8 @@ def parse_args():
                         help='Path to configuration file with hyper-parameters.')
     parser.add_argument('--tb_name', type=str, default=None,
                         help='Tensorboard path name for the run (allow multiples run with the same output path)')
+    parser.add_argument('--start_from', type=int, default=0,
+                        help='Position in the train set to start training from (default : 0)')
     parser.add_argument('--max_epoch', type=int, default=None,
                         help='Max epoch to train (no limitation if not provided)')
     parser.add_argument('--learn_rate', type=float, default=None,
@@ -289,9 +300,10 @@ def parse_args():
     group.add_argument('--evaluate', dest='evaluate', action='store_true', help='Evaluate WER against the test_set')
 
     args = parser.parse_args()
-    prog_params = {'config_file': args.config, 'tb_name': args.tb_name, 'max_epoch': args.max_epoch,
-                   'learn_rate': args.learn_rate, 'timeline': args.timeline, 'train': args.train,
-                   'file': args.file, 'record': args.record, 'evaluate': args.evaluate, 'XLA': args.XLA}
+    prog_params = {'config_file': args.config, 'tb_name': args.tb_name, 'start_from': args.start_from,
+                   'max_epoch': args.max_epoch, 'learn_rate': args.learn_rate, 'timeline': args.timeline,
+                   'train': args.train, 'file': args.file, 'record': args.record, 'evaluate': args.evaluate,
+                   'XLA': args.XLA}
     return prog_params
 
 


### PR DESCRIPTION
Training always start at the beginning of the training dataset, no more complicated use of global_step to try to continue from where it stopped.

New --start_from option for the user to be able to start at any point in the training dataset.